### PR TITLE
[質問] SerializeFieldからinterfaceを実装したコンポーネントをinterfaceの型で受け取りたい

### DIFF
--- a/Assets/MyGame/Prefabs/ResourceManager.prefab
+++ b/Assets/MyGame/Prefabs/ResourceManager.prefab
@@ -337,7 +337,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 580d97e00690eb1439126562d30851eb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _cookiesGeneratePerSecond: -18.6
+  _rpcProvider:
+    rid: 7060663624202977281
+  references:
+    version: 2
+    RefIds:
+    - rid: 7060663624202977281
+      type: {class: TestIRPSProvider, ns: , asm: Assembly-CSharp}
+      data:
+        _testRPS: 5
 --- !u!114 &7614788490499698054
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/MyGame/Scenes/MainScene.unity
+++ b/Assets/MyGame/Scenes/MainScene.unity
@@ -191,6 +191,24 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &646600083 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 3735301586359584552, guid: cfb13072a4098b446a80042e5bd723cd, type: 3}
+  m_PrefabInstance: {fileID: 1904376821247335349}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &646600087
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 646600083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2ba99dca88728fa45a4756ba03a6825d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _testRPS: 5
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -432,7 +450,10 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 3735301586359584552, guid: cfb13072a4098b446a80042e5bd723cd, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 646600087}
   m_SourcePrefab: {fileID: 100100000, guid: cfb13072a4098b446a80042e5bd723cd, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:

--- a/Assets/MyGame/Scripts/BaseSystem/ResourceManager.cs
+++ b/Assets/MyGame/Scripts/BaseSystem/ResourceManager.cs
@@ -1,21 +1,29 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UniRx;
-using UniRx.Triggers;
-using Unity.VisualScripting;
+
+
 /// <summary>
-/// フィールドにアタッチされていればResourceManager.Instance.○○で利用できるクラス。
-/// シングルトンを継承しています。
+/// 現在のリソースの秒間生産量を提供してほしい
 /// </summary>
+public interface IRpsProvider
+{
+    ReactiveProperty<float> CurrentRPS { get; set; }
+}
 public class ResourceManager : SingletonMonoBehavior<ResourceManager>
 {
-    [SerializeField,Header("リソーステスト　1秒間あたりのリソース生成量")] 
+    /// <summary>
+    /// ここでIRpsProviderを継承したコンポーネントを受け取りたい。
+    /// </summary>
+    [SerializeField] 
+    private IRpsProvider _rpsProvider;
+    private void Awake()
+    {
+        _rpsProvider.CurrentRPS.Subscribe(x => _resourceGeneratePerSecond = x);
+    }
+    
     private float _resourceGeneratePerSecond;
     private decimal _currentResources = 0;
-    //Calculate Classが現在のRPSを計算してほしい
-    private float _currentTestRPS;
     
     /// <summary>
     /// 現在のリソース値が変更された場合に呼ばれる
@@ -72,10 +80,7 @@ public class ResourceManager : SingletonMonoBehavior<ResourceManager>
     }
     
     
-    private void Start()
-    {
-        //this.ObserveEveryValueChanged(x => x._currentTestRPS).Subscribe(x => ResourceGeneratePerSecond = x);
-    }
+
 
     private void FixedUpdate()
     {
@@ -84,7 +89,7 @@ public class ResourceManager : SingletonMonoBehavior<ResourceManager>
 
     public void OnClick()
     {
-        _currentTestRPS += 0.1f;
+        //_currentTestRPS += 0.1f;
     }
 
 

--- a/Assets/MyGame/Scripts/Test/TestRpsProvider.cs
+++ b/Assets/MyGame/Scripts/Test/TestRpsProvider.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UniRx;
+using UnityEngine;
+
+[Serializable]
+public class TestRpsProvider : MonoBehaviour , IRpsProvider
+{
+    [SerializeField, Header("テスト用秒間資源生成量")]
+    private float _testRPS;
+    public ReactiveProperty<float> CurrentRPS { get; set; }
+
+    public TestRpsProvider()
+    {
+        CurrentRPS = new(_testRPS);
+    }
+}

--- a/Assets/MyGame/Scripts/Test/TestRpsProvider.cs.meta
+++ b/Assets/MyGame/Scripts/Test/TestRpsProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ba99dca88728fa45a4756ba03a6825d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
SerializeFieldから、MonoBehaviour継承してinterfaceを実装したコンポーネントを
interfaceの型として受け取りとることでテストや設計共有の効率化を図りたかったのですができませんでした(';')

機能をリクエストしている人もいました。Odinというアセットがあればできる？らしいです。
https://forum.unity.com/threads/serialized-interface-fields.1238785/

やりたい実装↓

https://github.com/VGA-Team2024/TeamA/blob/1851cedc55d7f00b939b77535c9ac1d5ba1a8059/Assets/MyGame/Scripts/Test/TestRpsProvider.cs#L7-L18

https://github.com/VGA-Team2024/TeamA/blob/1851cedc55d7f00b939b77535c9ac1d5ba1a8059/Assets/MyGame/Scripts/BaseSystem/ResourceManager.cs#L6-L25

